### PR TITLE
Update parse() to handle args that are tuples

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,22 +23,24 @@ class MethodRegistry {
   }
 
   parse (signature) {
-    let name = signature.match(/^.+(?=\()/)
-    
-    if (name) {
-      name = name[0].charAt(0).toUpperCase() + name[0].slice(1).split(/(?=[A-Z])/).join(' ')
+    const rawName = signature.match(new RegExp("^([^)(]*)\\((.*)\\)([^)(]*)$"))
+    let parsedName
+
+    if (rawName) {
+      parsedName = rawName[1].charAt(0).toUpperCase() + rawName[1].slice(1).split(/(?=[A-Z])/).join(' ')
     } else {
-      name = ''
+      parsedName = ''
     }
 
-    const match = signature.match(/\(.+\)/)
+    const match = signature.match(new RegExp(rawName[1] + '\\(+([a-z1-9,()]+)\\)'))
+
     let args = [];
     if (match) {
-      args = match[0].slice(1, -1).split(',').map((arg) => { return {type: arg}})
+      args = match[1].match(/[A-z1-9]+/g).map((arg) => { return {type: arg}})
     }
   
     return {
-      name,
+      name: parsedName,
       args
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-method-registry",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A module for getting method signature info from an ethereum method signature.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -74,3 +74,57 @@ test('parsing adds spaces to multi words', function (t) {
   t.end()
 })
 
+test('parse signature that includes a tuple as the first param', function (t) {
+  const sig = 'method((address,uint256,bytes),uint256,bytes)'
+  const parsed = registry.parse(sig)
+
+  t.equal(parsed.name, 'Method')
+  t.equal(parsed.args.length, 5)
+  t.equal(parsed.args[0].type, 'address')
+  t.equal(parsed.args[1].type, 'uint256')
+  t.equal(parsed.args[2].type, 'bytes')
+  t.equal(parsed.args[3].type, 'uint256')
+  t.equal(parsed.args[4].type, 'bytes')
+  t.end()
+})
+
+test('parse signature that includes a tuple of tuples', function (t) {
+  const sig = 'method(((address,uint256),(address,uint256)))'
+  const parsed = registry.parse(sig)
+
+  t.equal(parsed.name, 'Method')
+  t.equal(parsed.args.length, 4)
+  t.equal(parsed.args[0].type, 'address')
+  t.equal(parsed.args[1].type, 'uint256')
+  t.equal(parsed.args[2].type, 'address')
+  t.equal(parsed.args[3].type, 'uint256')
+  t.end()
+})
+
+test('parse signature that includes a tuple as a middle param', function (t) {
+  const sig = 'method(uint256,(address,uint256,bytes),bytes)'
+  const parsed = registry.parse(sig)
+
+  t.equal(parsed.name, 'Method')
+  t.equal(parsed.args.length, 5)
+  t.equal(parsed.args[0].type, 'uint256')
+  t.equal(parsed.args[1].type, 'address')
+  t.equal(parsed.args[2].type, 'uint256')
+  t.equal(parsed.args[3].type, 'bytes')
+  t.equal(parsed.args[4].type, 'bytes')
+  t.end()
+})
+
+test('parse signature that includes a tuple as the last param', function (t) {
+  const sig = 'method(uint256,bytes,(address,uint256,bytes))'
+  const parsed = registry.parse(sig)
+
+  t.equal(parsed.name, 'Method')
+  t.equal(parsed.args.length, 5)
+  t.equal(parsed.args[0].type, 'uint256')
+  t.equal(parsed.args[1].type, 'bytes')
+  t.equal(parsed.args[2].type, 'address')
+  t.equal(parsed.args[3].type, 'uint256')
+  t.equal(parsed.args[4].type, 'bytes')
+  t.end()
+})


### PR DESCRIPTION
fixes https://github.com/MetaMask/metamask-extension/issues/5983

This PR address an issue with parsing methods with signatures like `fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)`

Encodings of contract arguments can include tuples (and tuples within tuples, etc.) This will cause parenthesis to appear in the arg list of the signature. This could lead to the representation of method names and arguments with parameters included.

This PR ensures that the presence of tuples in method signatures does not cause parenthesis to appear in the string representation of the method name and its arguments.

Test cases are added.

Note that this will cause tuples to be represented flatly. I've created an issue for us to improve that in the future https://github.com/danfinlay/eth-method-registry/issues/7