### PR TITLE
Updates parse to handle array arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class MethodRegistry {
       parsedName = ''
     }
 
-    const match = signature.match(new RegExp(rawName[1] + '\\(+([a-z1-9,()]+)\\)'))
+    const match = signature.match(new RegExp(rawName[1] + '\\(+([a-z1-9,()\\[\\]]+)\\)'))
 
     let args = [];
     if (match) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-method-registry",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -128,3 +128,14 @@ test('parse signature that includes a tuple as the last param', function (t) {
   t.equal(parsed.args[4].type, 'bytes')
   t.end()
 })
+
+test('parse signature that includes an array param', function (t) {
+  const sig = 'method(uint256[],string)'
+  const parsed = registry.parse(sig)
+
+  t.equal(parsed.name, 'Method')
+  t.equal(parsed.args.length, 2)
+  t.equal(parsed.args[0].type, 'uint256[]')
+  t.equal(parsed.args[1].type, 'string')
+  t.end()
+})


### PR DESCRIPTION
PR to fix #10

`package-lock.json` seemed to be out of sync with `package.json`, so that autogenerated change is included as well.

Please let me know if you'd like me to bump up the minor version with this, or if there are any other tests I should add.