### PR TITLE
Remove broken default provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,10 @@ const abi = require('./abi')
 class MethodRegistry {
 
   constructor (opts = {}) {
-    this.provider = opts.provider ||
-      new Eth.HttpProvider('https://mainnet.infura.io/eth-contract-registry')
+    if (!opts.provider) {
+      throw new Error("Missing required 'provider' option")
+    }
+    this.provider = opts.provider
     this.eth = new Eth(this.provider)
     const address = registryMap[opts.network || '1']
 


### PR DESCRIPTION
The provider is now a required option. This seemed preferable to embedding another default provider that might also become obsolete. It's commonplace for eth-related libraries to require a provider to be passed in.