### PR TITLE
Update README to use Infura v3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With Node.js Installed:
 ```javascript
 const MethodRegistry = require('eth-method-registry')
 const Eth = require('ethjs')
-const provider = new Eth.HttpProvider('https://mainnet.infura.io')
+const provider = new Eth.HttpProvider('https://mainnet.infura.io/v3/YOUR-PROJECT-ID')
 const registry = new MethodRegistry({ provider })
 
 // Uses promises, pass the 4byte prefix to the lookup method:


### PR DESCRIPTION
The README example now includes a placeholder for the project ID, which is required with the Infura v3 API.