### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-01-13
+
+### Changed
+
+- Update `2.0.0` changelog entry to reflect missing breaking
+
 ## [2.0.0] - 2021-01-10
 
 ### Added
@@ -16,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **(SEMVER-MAJOR)** Require `provider` argument ([#15](https://github.com/MetaMask/eth-method-registry/pull/15))
+- **(SEMVER-MAJOR)** Move from default to named `MethodRegistry` export ([#21](https://github.com/MetaMask/eth-method-registry/pull/21))
 - Migrate to TypeScript ([#21](https://github.com/MetaMask/eth-method-registry/pull/21))
 
 ## [1.2.0] - 2019-04-15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-method-registry",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A module for getting method signature info from an ethereum method signature.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,5 +79,4 @@ export class MethodRegistry {
 
     return {};
   }
-
 }


### PR DESCRIPTION
- Patch version bump
- Update changelog
  - This is the point of the patch. The changelog was missing an entry, and we can't update it on npm without publishing a new version.
- Fix random spacing inconsistency