### PR TITLE
Make registry properties private

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,11 @@ interface DeployedRegistryContract {
 }
 
 export class MethodRegistry {
-  eth: Eth;
+  private eth: Eth;
 
-  provider: HttpProvider;
+  private provider: HttpProvider;
 
-  registry: DeployedRegistryContract;
+  private registry: DeployedRegistryContract;
 
   constructor(opts: MethodRegistryArgs) {
     if (!opts.provider) {


### PR DESCRIPTION
We don't make use of these properties in our use of this package, and being able to mutate them does make it easy to break this module. They have been made private, which dramatically decreases the API surface of this package.