### PR TITLE
add simple test for lookup

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,16 @@ const { MethodRegistry } = require('../dist');
 const { provider } = Ganache.server();
 const registry = new MethodRegistry({ provider });
 
+test('lookup on non-existing registry', async function (t) {
+  const result = await registry.lookup('0xdeadbeef');
+  t.equal(result, '');
+  t.end();
+});
+
+// TODO
+// test('lookup existing method', async function (t) { //...
+// test('lookup non-existing method', async function (t) { //...
+
 test('parse signature', function (t) {
   const sig = 'transfer(address,uint256)';
   const parsed = registry.parse(sig);


### PR DESCRIPTION
The `lookup` function does not have any tests.

This adds a simple first test for querying a non-existing registry. Could be a good idea to check in the bytecode (or solidity source and compile) and write tests loading the into ganache and testing against.