### PR TITLE
chore: fix contract type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Eth from '@metamask/ethjs';
+import type { DeployedRegistryContract } from '@metamask/ethjs-types';
 import registryMap from './registry-map.json';
 import abi from './abi.json';
 
@@ -10,10 +11,6 @@ interface HttpProvider {
 interface MethodRegistryArgs {
   network: string;
   provider: HttpProvider;
-}
-
-interface DeployedRegistryContract {
-  entries (bytes: string): string[];
 }
 
 export class MethodRegistry {
@@ -38,7 +35,7 @@ export class MethodRegistry {
  * @param bytes - The `0x`-prefixed hexadecimal string representing the four-byte signature of the contract method to lookup.
  */
   async lookup(bytes: string) {
-    const result: string[] | undefined = await this.registry.entries(bytes);
+    const result = await this.registry.entries(bytes);
     if (result) {
       return result[0];
     }

--- a/types/ethjs/index.d.ts
+++ b/types/ethjs/index.d.ts
@@ -1,14 +1,18 @@
+declare module '@metamask/ethjs-types' {
+  export interface RegistryContract {
+    at (address: string): DeployedRegistryContract;
+  }
+  export interface DeployedRegistryContract {
+    entries (bytes: string): Promise<string[]>;
+  }
+}
 declare module '@metamask/ethjs' {
+  import type { RegistryContract } from '@metamask/ethjs-types';
+
   class Eth {
     constructor(provider: any);
 
     contract(abi: Record<string, unknown>): RegistryContract;
-  }
-  interface RegistryContract {
-    at (address: string): DeployedRegistryContract;
-  }
-  interface DeployedRegistryContract {
-    entries (bytes: string): string[];
   }
   export=Eth;
 }


### PR DESCRIPTION
- fix: entries function is actually a Promise
  - it's also used internally as such: https://github.com/MetaMask/eth-method-registry/blob/4042e9f0e7d7583697b33e3415be8989292fc081/src/index.ts#L45
- remove type duplication