### PR TITLE
Add Shared Libraries team in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/devs
+*                                   @MetaMask/shared-libraries-engineers


### PR DESCRIPTION
Based on Github Teams Proposal we want to update codeowners to reflect the team(s) that should be consulted before a file is changed. In this case we are adding the Shared Libraries team.